### PR TITLE
Fix/run defaults match readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Only the API keys for the models you select and `MAX_CONCURRENCY` are strictly r
 The main entry point is `src/run.py`.  It currently wires up the 2025 evaluation challenges and defaults to `grok_config_prod` with `limit=1` so you can smoke-test the pipeline quickly.
 
 ```bash
-python src/run.py
+python -m src.run
 ```
 
 What happens:

--- a/src/run.py
+++ b/src/run.py
@@ -1033,7 +1033,7 @@ async def run() -> None:
         # task_ids={"b0039139", "20270e3b"},
     )
 
-    if solutions_path and attempts_path.exists():
+    if solutions_path:
         evaluate_solutions(
             attempts_solutions_path=attempts_path, truth_solutions_path=solutions_path
         )

--- a/src/run.py
+++ b/src/run.py
@@ -987,7 +987,7 @@ async def run_from_json(
 async def run() -> None:
     # Generate and print run ID at the start
 
-    year = "2024"
+    year = "2025"
     train_or_eval = "evaluation"
     root_dir = Path(__file__).parent.parent
 
@@ -1025,15 +1025,15 @@ async def run() -> None:
     await run_from_json(
         challenges_path=challenges_path,
         truth_solutions_path=solutions_path,
-        config=gpt5pro_config_prod,
+        config=grok_config_prod,
         attempts_path=attempts_path,
         temp_attempts_dir=temp_attempts_path,
-        limit=10,
-        offset=70,
+        limit=1,
+        offset=0,
         # task_ids={"b0039139", "20270e3b"},
     )
 
-    if solutions_path:
+    if solutions_path and attempts_path.exists():
         evaluate_solutions(
             attempts_solutions_path=attempts_path, truth_solutions_path=solutions_path
         )


### PR DESCRIPTION
This PR fixes the `run()` function to match what the README claims:

- Changed year from 2024 to 2025 (README says 2025 evaluation challenges)
- Changed config from `gpt5pro_config_prod` to `grok_config_prod` (README says defaults to grok_config_prod)
- Changed limit from 10 to 1 and offset from 70 to 0 (README says limit=1 for smoke test
- README update to use `python -m src.run` instead of `python src/run.py` (already committed).
- #6 #5 